### PR TITLE
ken_all_rome.zipを解凍したらKEN_ALL_ROME.csvのファイルが生成されるようになったため修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ gulp.task(
   "v1",
   gulp.series("download", () => {
     return gulp
-      .src("lib/api/KEN_ALL_ROME.CSV")
+      .src("lib/api/KEN_ALL_ROME.csv")
       .pipe(postal2json())
       .pipe(v1())
       .pipe(chmod(644))


### PR DESCRIPTION
fixed #17 

