### PR TITLE
解凍して出来るファイルがKEN_ALL_ROME.CSVになったことへの対応

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,6 @@
 name: update
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 15 * * *"
 jobs:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ gulp.task(
   "v1",
   gulp.series("download", () => {
     return gulp
-      .src("lib/api/KEN_ALL_ROME.csv")
+      .src("lib/api/KEN_ALL_ROME.CSV")
       .pipe(postal2json())
       .pipe(v1())
       .pipe(chmod(644))


### PR DESCRIPTION
fixed #19 

解凍したファイルが `KEN_ALL_ROME.CSV` になったためcase sensitiveなGitHub ActionsでのDeploy処理でファイルが見つからず失敗するのを修正しました．

合わせて手動でworkflowを実行できるようにトリガーに `workflow_dispatch ` を追加しました