### PR TITLE
GitHub Actionsで使用しているutuntu20.04がdeprecatedになったので22.04へ上げる

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 15 * * *"
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
問題が発生しているときのGitHub Actions: https://github.com/tokyootakumode/postal-code-api/actions/runs/14693331507 ❌ 

このブランチのGitHub Actions: https://github.com/tokyootakumode/postal-code-api/actions/runs/14697957593 ✅ 