### PR TITLE
郵便番号データのURL変更とGitHub ActionをNode.js v24で動作させるようにした

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,18 +6,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,20 +6,18 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "16"
+          node-version: "24.15"
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13-buster-slim
+FROM node:24.15-slim
 
 WORKDIR /home/node/app
 COPY lib lib

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,8 +11,8 @@ const v1 = require("./lib/v1.js");
 
 gulp.task("download", () => {
   const urls = [
-    "https://www.post.japanpost.jp/zipcode/dl/roman/KEN_ALL_ROME.zip",
-    "https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip",
+    "https://www.post.japanpost.jp/service/search/zipcode/download/roman/KEN_ALL_ROME.zip",
+    "https://www.post.japanpost.jp/service/search/zipcode/download/office/zip/jigyosyo.zip",
   ];
   return download(urls)
     .pipe(decompress())
@@ -33,7 +33,7 @@ gulp.task(
       .pipe(v1())
       .pipe(chmod(644))
       .pipe(gulp.dest("lib/api/v1"));
-  })
+  }),
 );
 
 /**
@@ -48,7 +48,7 @@ gulp.task(
       .pipe(v1())
       .pipe(chmod(644))
       .pipe(gulp.dest("lib/api/v1"));
-  })
+  }),
 );
 
 gulp.task("default", gulp.series(["v1", "v1-jigyosyo"]));


### PR DESCRIPTION

https://github.com/tokyootakumode/postal-code-api/actions/runs/25604508510 でGitHub Actionsがfailedになっていた

根本原因は郵便番号データのURLが変更になったことのようでした．
合わせてGitHub ActionsがDeprecatedになったNode.js v20で動いている旨のWarningが出ていたので修正した．


修正済みのActionを手動実行したところ問題なく動いた．
https://github.com/tokyootakumode/postal-code-api/actions/runs/25661850051